### PR TITLE
feat: integrate auto-palette as a Wasm module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,15 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
+# rust
+debug/
+target/
+bin/
+pkg/
+**/*.rs.bk
+Cargo.lock
+wasm-pack.log
+
 # intellij
 /.idea
 /.idea_modules

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,0 +1,12 @@
+include = ["./**/*.toml"]
+
+[formatting]
+align_entries  = true
+reorder_keys   = false
+reorder_arrays = false
+
+[[rule]]
+keys = ["dependencies", "dev-dependencies"]
+
+[rule.formatting]
+reorder_keys = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,21 @@
+[workspace]
+resolver = "2"
+members  = ["wasm"]
+
+[workspace.package]
+edition    = "2021"
+version    = "0.1.0"
+authors    = ["Tatsuya Maki"]
+license    = "MIT"
+homepage   = "https://github.com/t28hub/auto-palette-web"
+repository = "https://github.com/t28hub/auto-palette-web"
+
+[profile.dev]
+opt-level = 3
+
+[profile.test]
+opt-level = 3
+
+[profile.release]
+lto       = true
+opt-level = 's'

--- a/biome.json
+++ b/biome.json
@@ -3,7 +3,7 @@
   "files": {
     "ignoreUnknown": true,
     "include": ["**/*.js", "**/*.ts", "**/*.tsx", "**/*.json"],
-    "ignore": [".next", "node_modules", "coverage"]
+    "ignore": [".next", "node_modules", "coverage", "wasm/dist"]
   },
   "organizeImports": {
     "enabled": true

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,6 +2,19 @@
 const nextConfig = {
   experimental: {
     serverComponentsExternalPackages: ['pino', 'pino-pretty']
+  },
+  webpack: (config, { isServer, dev }) => {
+    if (isServer && !dev) {
+      config.output.webassemblyModuleFilename = "../static/wasm/[modulehash].wasm";
+    } else {
+      config.output.webassemblyModuleFilename = "static/wasm/[modulehash].wasm";
+    }
+
+    config.experiments = {
+      ...config.experiments,
+      asyncWebAssembly: true,
+    };
+    return config;
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -11,12 +11,16 @@
   "scripts": {
     "prepare": "husky",
     "preinstall": "npx only-allow pnpm",
-    "clean": "rimraf .next coverage",
-    "clean:all": "rimraf .next coverage node_modules",
-    "build": "next build",
+    "clean": "rimraf .next coverage target",
+    "clean:all": "rimraf .next coverage node_modules target wasm/dist",
+    "build": "pnpm build:wasm && pnpm build:app",
+    "build:app": "next build",
+    "build:wasm": "wasm-pack build --target web --out-name auto-palette --out-dir dist wasm",
     "dev": "next dev",
     "start": "next start",
-    "format": "biome format --write .",
+    "format": "pnpm format:biome && pnpm format:taplo",
+    "format:biome": "biome format --write .",
+    "format:taplo": "taplo format",
     "lint": "biome lint .",
     "lint:fix": "biome lint . --fix",
     "test": "pnpm test:coverage",
@@ -45,6 +49,7 @@
     "@biomejs/biome": "1.8.0",
     "@commitlint/cli": "^19.3.0",
     "@commitlint/config-conventional": "^19.2.2",
+    "@taplo/cli": "^0.7.0",
     "@testing-library/react": "^16.0.0",
     "@types/node": "^20.14.2",
     "@types/react": "^18.3.3",
@@ -60,11 +65,13 @@
     "rimraf": "^5.0.7",
     "tailwindcss": "^3.4.4",
     "typescript": "^5.4.5",
-    "vitest": "^1.6.0"
+    "vitest": "^1.6.0",
+    "wasm-pack": "^0.12.1"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": ["biome lint", "biome format --write"],
     "*.json": ["biome format --write"],
+    "*.toml": ["taplo format"],
     "*.md": ["markdownlint-cli2 --fix"]
   },
   "packageManager": "pnpm@9.2.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@commitlint/config-conventional':
         specifier: ^19.2.2
         version: 19.2.2
+      '@taplo/cli':
+        specifier: ^0.7.0
+        version: 0.7.0
       '@testing-library/react':
         specifier: ^16.0.0
         version: 16.0.0(@testing-library/dom@10.1.0)(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -111,6 +114,9 @@ importers:
       vitest:
         specifier: ^1.6.0
         version: 1.6.0(@types/node@20.14.2)(@vitest/ui@1.6.0)(jsdom@24.1.0)
+      wasm-pack:
+        specifier: ^0.12.1
+        version: 0.12.1
 
 packages:
 
@@ -984,6 +990,10 @@ packages:
   '@swc/helpers@0.5.5':
     resolution: {integrity: sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==}
 
+  '@taplo/cli@0.7.0':
+    resolution: {integrity: sha512-Ck3zFhQhIhi02Hl6T4ZmJsXdnJE+wXcJz5f8klxd4keRYgenMnip3JDPMGDRLbnC/2iGd8P0sBIQqI3KxfVjBg==}
+    hasBin: true
+
   '@testing-library/dom@10.1.0':
     resolution: {integrity: sha512-wdsYKy5zupPyLCW2Je5DLHSxSfbIp6h80WoHOQc+RPtmPGA52O9x5MJEkv92Sjonpq+poOAtUKhh1kBGAXBrNA==}
     engines: {node: '>=18'}
@@ -1152,6 +1162,9 @@ packages:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
 
+  axios@0.26.1:
+    resolution: {integrity: sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -1161,6 +1174,10 @@ packages:
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
+
+  binary-install@1.1.0:
+    resolution: {integrity: sha512-rkwNGW+3aQVSZoD0/o3mfPN6Yxh3Id0R/xzTVBVVpGNlVz8EGwusksxRlbk/A5iKTZt9zkMn3qIqmAt3vpfbzg==}
+    engines: {node: '>=10'}
 
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
@@ -1221,6 +1238,10 @@ packages:
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
+
+  chownr@2.0.0:
+    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
+    engines: {node: '>=10'}
 
   class-variance-authority@0.7.0:
     resolution: {integrity: sha512-jFI8IQw4hczaL4ALINxqLEXQbWcNjoSkloa4IaufXCJr6QawJyw7tuRysRsrE8w2p/4gGaxKIt/hX3qz/IbD1A==}
@@ -1483,6 +1504,15 @@ packages:
   flatted@3.3.1:
     resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
 
+  follow-redirects@1.15.6:
+    resolution: {integrity: sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   foreground-child@3.1.1:
     resolution: {integrity: sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==}
     engines: {node: '>=14'}
@@ -1490,6 +1520,10 @@ packages:
   form-data@4.0.0:
     resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
     engines: {node: '>= 6'}
+
+  fs-minipass@2.1.0:
+    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
+    engines: {node: '>= 8'}
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
@@ -1920,9 +1954,26 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  minipass@3.3.6:
+    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
+    engines: {node: '>=8'}
+
+  minipass@5.0.0:
+    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
+    engines: {node: '>=8'}
+
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  minizlib@2.1.2:
+    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
+    engines: {node: '>= 8'}
+
+  mkdirp@1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   mlly@1.7.1:
     resolution: {integrity: sha512-rrVRZRELyQzrIUAVMHxP97kv+G786pHmOKzuFII8zDYahFBS7qnHh2AlYSl1GAHhaMPCz6/oHjVMcfFYgFYHgA==}
@@ -2280,6 +2331,11 @@ packages:
   rfdc@1.3.1:
     resolution: {integrity: sha512-r5a3l5HzYlIC68TpmYKlxWjmOP6wiPJ1vWv2HeLhNsRZMrCkxeqxiHlQ21oXmQ4F3SiryXBHhAD7JZqvOJjFmg==}
 
+  rimraf@3.0.2:
+    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
   rimraf@5.0.7:
     resolution: {integrity: sha512-nV6YcJo5wbLW77m+8KjH8aB/7/rxQy9SZ0HY5shnwULfS+9nmTtVXAJET5NdZmCzA4fPI/Hm1wo/Po/4mopOdg==}
     engines: {node: '>=14.18'}
@@ -2473,6 +2529,10 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
+  tar@6.2.1:
+    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
+    engines: {node: '>=10'}
+
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
@@ -2654,6 +2714,10 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
+  wasm-pack@0.12.1:
+    resolution: {integrity: sha512-dIyKWUumPFsGohdndZjDXRFaokUT/kQS+SavbbiXVAvA/eN4riX5QNdB6AhXQx37zNxluxQkuixZUgJ8adKjOg==}
+    hasBin: true
+
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
@@ -2720,6 +2784,9 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
   yaml@2.4.3:
     resolution: {integrity: sha512-sntgmxj8o7DE7g/Qi60cqpLBA3HG3STcDA0kO+WfB05jEKhZMbY7umNm2rBpQvsmZ16/lPXCJGW2672dgOUkrg==}
@@ -3516,6 +3583,8 @@ snapshots:
       '@swc/counter': 0.1.3
       tslib: 2.6.3
 
+  '@taplo/cli@0.7.0': {}
+
   '@testing-library/dom@10.1.0':
     dependencies:
       '@babel/code-frame': 7.24.7
@@ -3722,11 +3791,25 @@ snapshots:
 
   atomic-sleep@1.0.0: {}
 
+  axios@0.26.1:
+    dependencies:
+      follow-redirects: 1.15.6
+    transitivePeerDependencies:
+      - debug
+
   balanced-match@1.0.2: {}
 
   base64-js@1.5.1: {}
 
   binary-extensions@2.3.0: {}
+
+  binary-install@1.1.0:
+    dependencies:
+      axios: 0.26.1
+      rimraf: 3.0.2
+      tar: 6.2.1
+    transitivePeerDependencies:
+      - debug
 
   brace-expansion@1.1.11:
     dependencies:
@@ -3803,6 +3886,8 @@ snapshots:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
+
+  chownr@2.0.0: {}
 
   class-variance-authority@0.7.0:
     dependencies:
@@ -4052,6 +4137,8 @@ snapshots:
 
   flatted@3.3.1: {}
 
+  follow-redirects@1.15.6: {}
+
   foreground-child@3.1.1:
     dependencies:
       cross-spawn: 7.0.3
@@ -4062,6 +4149,10 @@ snapshots:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
+
+  fs-minipass@2.1.0:
+    dependencies:
+      minipass: 3.3.6
 
   fs.realpath@1.0.0: {}
 
@@ -4479,7 +4570,20 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  minipass@3.3.6:
+    dependencies:
+      yallist: 4.0.0
+
+  minipass@5.0.0: {}
+
   minipass@7.1.2: {}
+
+  minizlib@2.1.2:
+    dependencies:
+      minipass: 3.3.6
+      yallist: 4.0.0
+
+  mkdirp@1.0.4: {}
 
   mlly@1.7.1:
     dependencies:
@@ -4825,6 +4929,10 @@ snapshots:
 
   rfdc@1.3.1: {}
 
+  rimraf@3.0.2:
+    dependencies:
+      glob: 7.2.3
+
   rimraf@5.0.7:
     dependencies:
       glob: 10.4.1
@@ -5033,6 +5141,15 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
+  tar@6.2.1:
+    dependencies:
+      chownr: 2.0.0
+      fs-minipass: 2.1.0
+      minipass: 5.0.0
+      minizlib: 2.1.2
+      mkdirp: 1.0.4
+      yallist: 4.0.0
+
   test-exclude@6.0.0:
     dependencies:
       '@istanbuljs/schema': 0.1.3
@@ -5195,6 +5312,12 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
+  wasm-pack@0.12.1:
+    dependencies:
+      binary-install: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
   webidl-conversions@7.0.0: {}
 
   whatwg-encoding@3.1.1:
@@ -5246,6 +5369,8 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
+
+  yallist@4.0.0: {}
 
   yaml@2.4.3: {}
 

--- a/src/providers/index.tsx
+++ b/src/providers/index.tsx
@@ -1,6 +1,7 @@
 import type { FC, PropsWithChildren } from 'react';
 import { ThemeProvider } from './theme-provider';
 import { ShikiProvider } from './shiki-provider';
+import { WasmProvider } from '@/providers/wasm-provider';
 
 /**
  * The composite providers component.
@@ -9,7 +10,7 @@ const Providers: FC<PropsWithChildren> = ({ children }) => {
   return (
     <ThemeProvider attribute='class' defaultTheme='system' enableSystem disableTransitionOnChange>
       <ShikiProvider light='github-light' dark='github-dark'>
-        {children}
+        <WasmProvider>{children}</WasmProvider>
       </ShikiProvider>
     </ThemeProvider>
   );

--- a/src/providers/wasm-provider.tsx
+++ b/src/providers/wasm-provider.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import {
+  createContext,
+  type FC,
+  type PropsWithChildren,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import init, { extract as extractPalette, type InitOutput, type PaletteBinding } from '@/wasm/auto-palette';
+import { logger } from '@/utils';
+
+/**
+ * The Context for the Wasm module.
+ */
+interface WasmContext {
+  /**
+   * Extract a palette from the given image.
+   *
+   * @param image - The image to extract the palette from.
+   * @returns The extracted palette.
+   */
+  extract: (image: ImageBitmap) => PaletteBinding;
+}
+
+const Context = createContext<WasmContext>({
+  extract: () => {
+    throw new Error('Wasm module not initialized yet');
+  },
+});
+
+const WasmProvider: FC<PropsWithChildren> = ({ children }) => {
+  const module = useWasmModule();
+
+  const extract = useCallback(
+    (image: ImageBitmap) => {
+      if (!module) {
+        throw new Error('Wasm module not initialized yet');
+      }
+
+      const { width, height } = image;
+      const canvas = new OffscreenCanvas(width, height);
+      const context = canvas.getContext('2d', { alpha: true });
+      if (!context) {
+        throw new Error('The 2D context is not available on the canvas');
+      }
+
+      context.drawImage(image, 0, 0);
+
+      const imageData = context.getImageData(0, 0, width, height);
+      return extractPalette(width, height, imageData.data, 'dbscan++');
+    },
+    [module],
+  );
+
+  const value = useMemo(() => {
+    return { extract };
+  }, [extract]);
+
+  return <Context.Provider value={value}>{children}</Context.Provider>;
+};
+
+const useWasmModule = (): InitOutput | null => {
+  const [output, setOutput] = useState<InitOutput | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const abortListener = () => {
+      controller.signal.removeEventListener('abort', abortListener);
+    };
+    controller.signal.addEventListener('abort', abortListener);
+
+    init()
+      .then((initialized) => {
+        logger.info('Wasm module initialized', initialized);
+        if (controller.signal.aborted) {
+          return;
+        }
+        setOutput(initialized);
+      })
+      .catch((error) => {
+        logger.warn('Failed to initialize Wasm module', error);
+        setOutput(null);
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, []);
+
+  return output;
+};
+
+/**
+ * The hook that uses the Wasm context.
+ *
+ * @returns The Wasm context.
+ */
+const useWasm = () => useContext(Context);
+
+export { WasmProvider, useWasm };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@/wasm/*": ["./wasm/dist/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name                 = "auto-palette-wasm"
+rust-version         = "1.75.0"
+description          = "The WebAssembly bindings for the Auto Palette library."
+readme               = "./README.md"
+publish              = false
+edition.workspace    = true
+version.workspace    = true
+authors.workspace    = true
+license.workspace    = true
+homepage.workspace   = true
+repository.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+auto-palette = { version = "0.4.0", features = [
+  "wasm",
+], default-features = false }
+console_error_panic_hook = "0.1.7"
+js-sys = "0.3.69"
+wasm-bindgen = "0.2.92"

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -1,0 +1,3 @@
+# auto-palette-wasm
+
+> `auto-palette-wasm` is a WebAssembly module that provides a function to generate a color palette from an image.

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,0 +1,81 @@
+use auto_palette::{Algorithm, ImageData, Palette, Swatch, Theme};
+use wasm_bindgen::{prelude::wasm_bindgen, Clamped, JsValue};
+use std::str::FromStr;
+
+#[wasm_bindgen]
+#[derive(Debug)]
+pub struct SwatchBinding(Swatch<f64>);
+
+#[wasm_bindgen]
+impl SwatchBinding {
+  #[wasm_bindgen(getter)]
+  pub fn color(&self) -> String {
+    self.0.color().to_hex_string()
+  }
+
+  #[wasm_bindgen(getter)]
+  pub fn position(&self) -> String {
+    let (x, y) = self.0.position();
+    format!("({}, {})", x, y)
+  }
+
+  #[wasm_bindgen(getter)]
+  pub fn population(&self) -> usize {
+    self.0.population()
+  }
+
+  #[wasm_bindgen(getter)]
+  pub fn ratio(&self) -> f64 {
+    self.0.ratio()
+  }
+}
+
+#[wasm_bindgen]
+#[derive(Debug)]
+pub struct PaletteBinding(Palette<f64>);
+
+#[wasm_bindgen]
+impl PaletteBinding {
+  #[wasm_bindgen(getter)]
+  pub fn length(&self) -> usize {
+    self.0.len()
+  }
+
+  #[wasm_bindgen(js_name = isEmpty)]
+  pub fn is_empty(&self) -> bool {
+    self.0.is_empty()
+  }
+
+  #[wasm_bindgen(js_name = findSwatches)]
+  pub fn find_swatches(&self, n: usize, theme: String) -> Result<Vec<SwatchBinding>, JsValue> {
+    let theme = Theme::from_str(&theme).map_err(|e| JsValue::from_str(&e.to_string()))?;
+    let found = self.0
+      .find_swatches_with_theme(n, theme)
+      .into_iter()
+      .map(SwatchBinding)
+      .collect();
+    Ok(found)
+  }
+}
+
+#[wasm_bindgen]
+pub fn extract(
+  width: u32,
+  height: u32,
+  data: Clamped<Vec<u8>>,
+  algorithm: String,
+) -> Result<PaletteBinding, JsValue> {
+  console_error_panic_hook::set_once();
+
+  let image_data = ImageData::new(width, height, &data.0).map_err(|e| {
+    JsValue::from_str(&e.to_string())
+  })?;
+  let algorithm = Algorithm::from_str(&algorithm).map_err(|e| {
+    JsValue::from_str(&e.to_string())
+  })?;
+  let palette = Palette::extract_with_algorithm(&image_data, algorithm)
+    .map_err(|e| {
+      JsValue::from_str(&e.to_string())
+    })?;
+  Ok(PaletteBinding(palette))
+}


### PR DESCRIPTION
## Description

In this pull request, the `auto-palette` library, which is implemented in Rust, has been integrated as a WebAssembly module. This allows the application to leverage the color palette extraction capabilities of `auto-palette` directly in the browser.

## Related Issue

No related issue.

## Type of Change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
