### PR TITLE
feat(hooks): add useBitmap hook for ImageBitmap loading from URL

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './use-bitmap';

--- a/src/hooks/use-bitmap.ts
+++ b/src/hooks/use-bitmap.ts
@@ -1,0 +1,87 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * The result of the useBitmap hook.
+ */
+interface UseBitmapResult {
+  /**
+   * The loaded image bitmap.
+   */
+  readonly bitmap: ImageBitmap | null;
+
+  /**
+   * The error that occurred while loading the image bitmap.
+   */
+  readonly error: Error | null;
+}
+
+/**
+ * An error that occurred while loading an image bitmap.
+ */
+class NetworkError extends Error {
+  /**
+   * Create a new network error.
+   *
+   * @param message - The error message.
+   */
+  constructor(message: string) {
+    super(message);
+    this.name = 'NetworkError';
+  }
+}
+
+/**
+ * Load an image bitmap from the given URL.
+ *
+ * @param url - The URL of the image to load.
+ * @returns The result of the useBitmap hook.
+ */
+const useBitmap = (url: string | undefined): UseBitmapResult => {
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const [bitmap, setBitmap] = useState<ImageBitmap | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    abortControllerRef.current?.abort();
+
+    if (!url) {
+      setBitmap(null);
+      setError(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+
+    fetch(url, { mode: 'cors', signal: controller.signal })
+      .then((response) => {
+        if (!response.ok) {
+          throw new NetworkError(`Received ${response.status} ${response.statusText} for ${url}`);
+        }
+        return response.blob();
+      })
+      .then((blob) => createImageBitmap(blob))
+      .then((imageBitmap) => {
+        if (controller.signal.aborted) {
+          return;
+        }
+        setBitmap(imageBitmap);
+      })
+      .catch((error) => {
+        if (controller.signal.aborted) {
+          return;
+        }
+        setError(error);
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [url]);
+
+  return { bitmap, error };
+};
+
+export { useBitmap };


### PR DESCRIPTION
## Description

In this pull request, a new `useBitmap` hook was added for ImageBitmap loading from URL.

## Related Issue

No related issue.

## Type of Change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
