### PR TITLE
feat(hooks): add usePalette hook for extracting palette from ImageBitmap

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './use-bitmap';
+export * from './use-palette';

--- a/src/hooks/use-palette.ts
+++ b/src/hooks/use-palette.ts
@@ -1,0 +1,73 @@
+import { useCallback, useEffect, useState } from 'react';
+import { extract as extractPalette, type Palette } from '@/wasm/auto-palette';
+import { useWasm } from '@/providers/wasm-provider';
+
+/**
+ * The result of the usePalette hook.
+ */
+interface UsePaletteResult {
+  /**
+   * The extracted palette.
+   */
+  readonly palette: Palette | null;
+
+  /**
+   * The error that occurred while extracting the palette.
+   */
+  readonly error: Error | null;
+}
+
+/**
+ * Extract the palette from the given image bitmap using the specified algorithm.
+ *
+ * @param bitmap - The image bitmap to extract the palette from.
+ * @param algorithm - The algorithm to use for extracting the palette.
+ * @returns The result of the usePalette hook.
+ */
+const usePalette = (bitmap: ImageBitmap | null, algorithm: string): UsePaletteResult => {
+  const { module } = useWasm();
+  const [palette, setPalette] = useState<Palette | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+
+  const extract = useCallback(
+    (image: ImageBitmap, algorithm: string) => {
+      if (!module) {
+        throw new Error('Wasm module not initialized yet');
+      }
+
+      const { width, height } = image;
+      const canvas = new OffscreenCanvas(width, height);
+      const context = canvas.getContext('2d', { alpha: true });
+      if (!context) {
+        throw new Error('The 2D context is not available on the canvas');
+      }
+
+      context.drawImage(image, 0, 0);
+
+      const imageData = context.getImageData(0, 0, width, height);
+      return extractPalette(width, height, imageData.data, algorithm);
+    },
+    [module],
+  );
+
+  useEffect(() => {
+    if (!module) {
+      return;
+    }
+
+    if (!bitmap) {
+      setPalette(null);
+      setError(null);
+      return;
+    }
+
+    try {
+      const palette = extract(bitmap, algorithm);
+      setPalette(palette);
+    } catch (error) {
+      setError(new Error(`Failed to extract the palette: ${error}`));
+    }
+  }, [module, extract, bitmap, algorithm]);
+
+  return { palette, error };
+};

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -2,7 +2,7 @@ use auto_palette::{Algorithm, ImageData, Palette, Swatch, Theme};
 use wasm_bindgen::{prelude::wasm_bindgen, Clamped, JsValue};
 use std::str::FromStr;
 
-#[wasm_bindgen]
+#[wasm_bindgen(js_name = Swatch)]
 #[derive(Debug)]
 pub struct SwatchBinding(Swatch<f64>);
 
@@ -30,7 +30,7 @@ impl SwatchBinding {
   }
 }
 
-#[wasm_bindgen]
+#[wasm_bindgen(js_name = Palette)]
 #[derive(Debug)]
 pub struct PaletteBinding(Palette<f64>);
 


### PR DESCRIPTION
## Description

In this pull request, a new `usePalette` hook was added for extracting palette from `ImageData.

## Related Issue

No related issue.

## Type of Change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
