### PR TITLE
feat: implement component for displaying ImageBitmap and add DemoLayout

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/card';
 import { Footer, Header } from '@/components/layouts';
 import { CodeIcon, CogIcon, PaletteIcon, PipetteIcon, SwatchIcon, WandIcon } from '@/components/icons';
 import { Code } from '@/components/code';
+import { DemoLayout } from '@/layouts';
 
 export default function Home() {
   return (
@@ -9,6 +10,8 @@ export default function Home() {
       <Header />
 
       <main className='container flex min-h-screen flex-col items-center justify-between gap-4 py-24'>
+        <DemoLayout />
+
         <section className='w-full min-w-screen-sm  max-w-screen-lg flex items-center justify-start'>
           <div className='w-full rounded-lg border-foreground bg-accent'>
             <Code language='rust'>

--- a/src/components/image/bitmap-image.tsx
+++ b/src/components/image/bitmap-image.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { type FC, useEffect, useRef, useState } from 'react';
+import { logger } from '@/utils';
+
+interface BitmapImageProps {
+  readonly bitmap: ImageBitmap | null;
+  readonly height: number;
+  readonly width: number;
+  readonly objectFit?: 'contain' | 'cover' | 'fill' | 'none' | 'scale-down';
+}
+
+const BitmapImage: FC<BitmapImageProps> = ({ bitmap, height, width, objectFit = 'none' }) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const [scaledBitmap, setScaledBitmap] = useState<ImageBitmap | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      return;
+    }
+
+    if (!bitmap) {
+      setScaledBitmap(null);
+      return;
+    }
+
+    const { width: bitmapWidth, height: bitmapHeight } = bitmap;
+    const { width: canvasWidth, height: canvasHeight } = canvas;
+    let scaleX = canvasWidth / bitmapWidth;
+    let scaleY = canvasHeight / bitmapHeight;
+    switch (objectFit) {
+      case 'contain': {
+        const scale = Math.min(scaleX, scaleY);
+        scaleX = scale;
+        scaleY = scale;
+        break;
+      }
+      case 'cover': {
+        const scale = Math.max(scaleX, scaleY);
+        scaleX = scale;
+        scaleY = scale;
+        break;
+      }
+      case 'fill': {
+        // Use the default scale values
+        break;
+      }
+      case 'scale-down': {
+        const scale = Math.min(Math.min(scaleX, scaleY), 1.0);
+        scaleX = scale;
+        scaleY = scale;
+        break;
+      }
+      case 'none': {
+        scaleX = 1.0;
+        scaleY = 1.0;
+        break;
+      }
+      default: {
+        scaleX = 1.0;
+        scaleY = 1.0;
+        break;
+      }
+    }
+
+    console.info(scaleX, scaleY);
+
+    createImageBitmap(bitmap, {
+      resizeHeight: bitmapHeight * scaleY,
+      resizeWidth: bitmapWidth * scaleX,
+      resizeQuality: 'medium',
+    })
+      .then((imageBitmap) => {
+        setScaledBitmap(imageBitmap);
+      })
+      .catch((error) => {
+        logger.error(`Failed to resize image bitmap: ${error.message}`);
+      });
+  }, [bitmap, objectFit]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      return;
+    }
+
+    const context = canvas.getContext('2d', { alpha: true });
+    if (!context) {
+      logger.warn('The 2d context is not available on the canvas');
+      return;
+    }
+
+    context.clearRect(0, 0, canvas.width, canvas.height);
+    if (!scaledBitmap) {
+      return;
+    }
+
+    const { width, height } = scaledBitmap;
+    const dx = (canvas.width - width) / 2;
+    const dy = (canvas.height - height) / 2;
+    context.drawImage(scaledBitmap, dx, dy);
+  }, [scaledBitmap]);
+
+  return <canvas className='block' ref={canvasRef} height={height} width={width} />;
+};
+BitmapImage.displayName = 'BitmapImage';
+
+export { BitmapImage };

--- a/src/components/image/index.ts
+++ b/src/components/image/index.ts
@@ -1,0 +1,1 @@
+export * from './bitmap-image';

--- a/src/hooks/use-palette.ts
+++ b/src/hooks/use-palette.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useCallback, useEffect, useState } from 'react';
 import { extract as extractPalette, type Palette } from '@/wasm/auto-palette';
 import { useWasm } from '@/providers/wasm-provider';
@@ -71,3 +73,5 @@ const usePalette = (bitmap: ImageBitmap | null, algorithm: string): UsePaletteRe
 
   return { palette, error };
 };
+
+export { usePalette };

--- a/src/layouts/demo.tsx
+++ b/src/layouts/demo.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { type FC, useEffect, useState } from 'react';
+import { BitmapImage } from '@/components/image';
+import { useBitmap, usePalette } from '@/hooks';
+import { logger } from '@/utils';
+
+const DemoLayout: FC = () => {
+  const { bitmap, error } = useBitmap(
+    'https://images.unsplash.com/photo-1718775971170-bab41e147a9f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w1NTc4MjR8MHwxfGFsbHw3fHx8fHx8Mnx8MTcxOTU2NzAwM3w&ixlib=rb-4.0.3&q=80&w=400',
+  );
+  const { palette, error: paletteError } = usePalette(bitmap, 'dbscan++');
+
+  useEffect(() => {
+    if (!palette && !paletteError) {
+      return;
+    }
+
+    if (paletteError) {
+      logger.error(`Failed to extract palette: ${paletteError.message}`);
+      return;
+    }
+
+    if (palette) {
+      logger.info(`Extracted ${palette.length} swatches`);
+      const swatches = palette.findSwatches(5, 'basic');
+      for (const swatch of swatches) {
+        logger.info(`Color: ${swatch.color}`);
+        logger.info(`Population: ${swatch.population}`);
+        logger.info(`Ratio: ${swatch.ratio}`);
+      }
+    }
+  }, [palette, paletteError]);
+
+  return (
+    <section className='w-full min-w-screen-sm  max-w-screen-lg flex items-center justify-start'>
+      <div className='h-full w-full overflow-hidden rounded-lg bg-image-placeholder bg-4'>
+        {bitmap && <BitmapImage bitmap={bitmap} height={450} width={800} objectFit='cover' />}
+      </div>
+    </section>
+  );
+};
+
+export { DemoLayout };

--- a/src/layouts/index.ts
+++ b/src/layouts/index.ts
@@ -1,0 +1,1 @@
+export * from './demo';

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 #[derive(Debug)]
 pub struct SwatchBinding(Swatch<f64>);
 
-#[wasm_bindgen]
+#[wasm_bindgen(js_class = Swatch)]
 impl SwatchBinding {
   #[wasm_bindgen(getter)]
   pub fn color(&self) -> String {
@@ -34,7 +34,7 @@ impl SwatchBinding {
 #[derive(Debug)]
 pub struct PaletteBinding(Palette<f64>);
 
-#[wasm_bindgen]
+#[wasm_bindgen(js_class = Palette)]
 impl PaletteBinding {
   #[wasm_bindgen(getter)]
   pub fn length(&self) -> usize {


### PR DESCRIPTION
## Description

In this pull request, a new `BitmapImage` component for displaying `ImageBitmap` on canvas was added.  
It also adds a `DemoLayout` component that uses the `BitmapImage` component to display a demo of the `AutoPalette` feature.

## Related Issue

No related issue.

## Type of Change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
