### PR TITLE
feat(ui): maintain aspect ratio for bitmap images in DemoLayout

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test:watch": "vitest --watch"
   },
   "dependencies": {
+    "@radix-ui/react-aspect-ratio": "^1.1.0",
     "@radix-ui/react-dropdown-menu": "^2.1.1",
     "@radix-ui/react-slot": "^1.0.2",
     "class-variance-authority": "^0.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@radix-ui/react-aspect-ratio':
+        specifier: ^1.1.0
+        version: 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.1
         version: 2.1.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -624,6 +627,19 @@ packages:
 
   '@radix-ui/react-arrow@1.1.0':
     resolution: {integrity: sha512-FmlW1rCg7hBpEBwFbjHwCW6AmWLQM6g/v0Sn8XbP9NvmSZ2San1FpQeyPtufzOMSIx7Y4dzjlHoifhp+7NkZhw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-aspect-ratio@1.1.0':
+    resolution: {integrity: sha512-dP87DM/Y7jFlPgUZTlhx6FF5CEzOiaxp2rBCKlaXlpH5Ip/9Fg5zZ9lDOQ5o/MOfUlf36eak14zoWYpgcgGoOg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3278,6 +3294,15 @@ snapshots:
   '@radix-ui/primitive@1.1.0': {}
 
   '@radix-ui/react-arrow@1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
+
+  '@radix-ui/react-aspect-ratio@1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1

--- a/src/components/image/bitmap-image.tsx
+++ b/src/components/image/bitmap-image.tsx
@@ -14,6 +14,7 @@ const BitmapImage: FC<BitmapImageProps> = ({ bitmap, height, width, objectFit = 
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const [scaledBitmap, setScaledBitmap] = useState<ImageBitmap | null>(null);
 
+  // Effect for resizing the image bitmap
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) {
@@ -64,8 +65,6 @@ const BitmapImage: FC<BitmapImageProps> = ({ bitmap, height, width, objectFit = 
       }
     }
 
-    console.info(scaleX, scaleY);
-
     createImageBitmap(bitmap, {
       resizeHeight: bitmapHeight * scaleY,
       resizeWidth: bitmapWidth * scaleX,
@@ -79,6 +78,7 @@ const BitmapImage: FC<BitmapImageProps> = ({ bitmap, height, width, objectFit = 
       });
   }, [bitmap, objectFit]);
 
+  // Effect for drawing the scaled image bitmap
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) {
@@ -96,11 +96,11 @@ const BitmapImage: FC<BitmapImageProps> = ({ bitmap, height, width, objectFit = 
       return;
     }
 
-    const { width, height } = scaledBitmap;
-    const dx = (canvas.width - width) / 2;
-    const dy = (canvas.height - height) / 2;
+    const { width: bitmapWidth, height: bitmapHeight } = scaledBitmap;
+    const dx = (width - bitmapWidth) / 2;
+    const dy = (height - bitmapHeight) / 2;
     context.drawImage(scaledBitmap, dx, dy);
-  }, [scaledBitmap]);
+  }, [width, height, scaledBitmap]);
 
   return <canvas className='block' ref={canvasRef} height={height} width={width} />;
 };

--- a/src/components/ui/aspect-ratio.tsx
+++ b/src/components/ui/aspect-ratio.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import * as AspectRatioPrimitive from '@radix-ui/react-aspect-ratio';
+
+const AspectRatio = AspectRatioPrimitive.Root;
+
+export { AspectRatio };

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,2 +1,3 @@
+export * from './aspect-ratio';
 export * from './button';
 export * from './dropdown-menu';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from './use-bitmap';
+export * from './use-element-size';
 export * from './use-palette';

--- a/src/hooks/use-bitmap.ts
+++ b/src/hooks/use-bitmap.ts
@@ -38,7 +38,7 @@ class NetworkError extends Error {
  * @param url - The URL of the image to load.
  * @returns The result of the useBitmap hook.
  */
-const useBitmap = (url: string | undefined): UseBitmapResult => {
+const useBitmap = (url: string | null): UseBitmapResult => {
   const abortControllerRef = useRef<AbortController | null>(null);
   const [bitmap, setBitmap] = useState<ImageBitmap | null>(null);
   const [error, setError] = useState<Error | null>(null);
@@ -55,7 +55,7 @@ const useBitmap = (url: string | undefined): UseBitmapResult => {
     const controller = new AbortController();
     abortControllerRef.current = controller;
 
-    fetch(url, { mode: 'cors', signal: controller.signal })
+    fetch(url, { mode: 'cors', cache: 'default', signal: controller.signal })
       .then((response) => {
         if (!response.ok) {
           throw new NetworkError(`Received ${response.status} ${response.statusText} for ${url}`);

--- a/src/hooks/use-element-size.ts
+++ b/src/hooks/use-element-size.ts
@@ -1,0 +1,58 @@
+'use client';
+
+import { type RefObject, useCallback, useLayoutEffect, useState } from 'react';
+
+/**
+ * The size of an element.
+ */
+interface Size {
+  /**
+   * The width of the element.
+   */
+  readonly width: number;
+
+  /**
+   * The height of the element.
+   */
+  readonly height: number;
+}
+
+/**
+ * Get the size of an element.
+ *
+ * @param ref - The reference to the element.
+ * @returns The size of the element.
+ */
+const useElementSize = <T extends HTMLElement = HTMLDivElement>(ref: RefObject<T | null>): Size => {
+  const [size, setSize] = useState<Size>({ width: 0, height: 0 });
+
+  const onResize = useCallback(() => {
+    const element = ref.current;
+    if (!element) {
+      return;
+    }
+
+    const { width, height } = element.getBoundingClientRect();
+    setSize({ width, height });
+  }, [ref]);
+
+  useLayoutEffect(() => {
+    const element = ref.current;
+    if (!element) {
+      return;
+    }
+
+    onResize();
+
+    const resizeObserver = new ResizeObserver(onResize);
+    resizeObserver.observe(element);
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, [ref, onResize]);
+
+  return size;
+};
+
+export { type Size, useElementSize };

--- a/src/layouts/demo.tsx
+++ b/src/layouts/demo.tsx
@@ -1,11 +1,18 @@
 'use client';
 
-import { type FC, useEffect, useState } from 'react';
+import { type FC, useEffect, useRef } from 'react';
 import { BitmapImage } from '@/components/image';
-import { useBitmap, usePalette } from '@/hooks';
+import { useBitmap, useElementSize, usePalette } from '@/hooks';
 import { logger } from '@/utils';
+import { AspectRatio } from '@/components/ui';
 
+/**
+ *
+ * @constructor
+ */
 const DemoLayout: FC = () => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const containerSize = useElementSize(containerRef);
   const { bitmap, error } = useBitmap(
     'https://images.unsplash.com/photo-1718775971170-bab41e147a9f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w1NTc4MjR8MHwxfGFsbHw3fHx8fHx8Mnx8MTcxOTU2NzAwM3w&ixlib=rb-4.0.3&q=80&w=400',
   );
@@ -34,9 +41,13 @@ const DemoLayout: FC = () => {
 
   return (
     <section className='w-full min-w-screen-sm  max-w-screen-lg flex items-center justify-start'>
-      <div className='h-full w-full overflow-hidden rounded-lg bg-image-placeholder bg-4'>
-        {bitmap && <BitmapImage bitmap={bitmap} height={450} width={800} objectFit='cover' />}
-      </div>
+      <AspectRatio ref={containerRef} ratio={16 / 9} asChild className='flex items-center justify-center relative'>
+        <div className='h-full w-full overflow-hidden rounded-lg bg-image-placeholder bg-4'>
+          {bitmap && (
+            <BitmapImage bitmap={bitmap} height={containerSize.height} width={containerSize.width} objectFit='cover' />
+          )}
+        </div>
+      </AspectRatio>
     </section>
   );
 };


### PR DESCRIPTION
## Description

This PR revises the implementation of the DemoLayout to ensure that images are displayed while maintaining their aspect ratio.

## Related Issue

No related issue.

## Type of Change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
