### PR TITLE
feat(hooks): implement useCopy for copying text to clipboard

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from './use-bitmap';
+export * from './use-copy';
 export * from './use-element-size';
 export * from './use-palette';

--- a/src/hooks/use-copy.ts
+++ b/src/hooks/use-copy.ts
@@ -1,0 +1,73 @@
+import { useCallback, useEffect, useState } from 'react';
+
+/**
+ * The options for the useCopy hook.
+ */
+interface UseCopyOptions {
+  /**
+   * The duration to display the copied message.
+   */
+  readonly duration?: number;
+}
+
+/**
+ * The result of the useCopy hook.
+ */
+interface UseCopyResult {
+  /**
+   * The copy function.
+   */
+  readonly copy: (text: string) => void;
+
+  /**
+   * The error that occurred during copying.
+   */
+  readonly error: Error | null;
+
+  /**
+   * The copied state.
+   */
+  readonly copied: boolean;
+}
+
+/**
+ * The useCopy hook copies text to the clipboard.
+ *
+ * @param options - The options for the hook.
+ * @returns The result of the hook.
+ */
+const useCopy = ({ duration = 2000 }: UseCopyOptions = {}): UseCopyResult => {
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const copy = useCallback((text: string) => {
+    navigator.clipboard
+      .writeText(text)
+      .then(() => {
+        setCopied(true);
+        setError(null);
+      })
+      .catch((cause) => {
+        setCopied(false);
+        setError(cause);
+      });
+  }, []);
+
+  useEffect(() => {
+    if (!copied) {
+      return;
+    }
+
+    const id = setTimeout(() => {
+      setCopied(false);
+    }, duration);
+
+    return () => {
+      clearTimeout(id);
+    };
+  }, [copied, duration]);
+
+  return { copy, error, copied };
+};
+
+export { useCopy };

--- a/test/hooks/use-copy.test.ts
+++ b/test/hooks/use-copy.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useCopy } from '@/hooks/use-copy';
+
+describe('useCopy', () => {
+  test('should copy the text to the clipboard', () => {
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn(() => Promise.resolve()),
+      },
+    });
+
+    const { result } = renderHook(() => useCopy({ duration: 0 }));
+    result.current.copy('Hello, World!');
+
+    // Verify the text is copied to the clipboard
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('Hello, World!');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     include: ['**/*.test.{ts,tsx}'],
     alias: {
       '@': resolve(__dirname, 'src'),
+      '@/wasm/auto-palette': resolve(__dirname, './wasm/dist/auto-palette.js'),
     },
     environment: 'jsdom',
     testTimeout: 1000,


### PR DESCRIPTION
## Description

This PR introduces the `useCopy` hook, which provides an easy and reusable way to copy text to the clipboard.

## Related Issue

No related issue.

## Type of Change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
