### PR TITLE
feat(component): add Heading component and replace from HTMLHeadingElement

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@ import { Footer, Header } from '@/components/layouts';
 import { CodeIcon, CogIcon, PaletteIcon, PipetteIcon, SwatchIcon, WandIcon } from '@/components/icons';
 import { Code } from '@/components/code';
 import { DemoLayout } from '@/layouts';
+import { Heading } from '@/components/typography';
 
 export default function Home() {
   return (
@@ -12,7 +13,10 @@ export default function Home() {
       <main className='container flex min-h-screen flex-col items-center justify-between gap-4 py-24'>
         <DemoLayout />
 
-        <section className='w-full min-w-screen-sm  max-w-screen-lg flex items-center justify-start'>
+        <section className='w-full min-w-screen-sm  max-w-screen-lg flex flex-col items-start justify-start mt-4'>
+          <Heading as='h2' size='xl'>
+            Example
+          </Heading>
           <div className='w-full rounded-lg border-foreground bg-accent'>
             <Code language='rust'>
               {'use auto_palette::{ImageData, Palette};'}
@@ -38,7 +42,10 @@ export default function Home() {
           </div>
         </section>
 
-        <section className='w-full min-w-screen-sm  max-w-screen-lg flex items-center justify-start'>
+        <section className='w-full min-w-screen-sm max-w-screen-lg flex flex-col items-start justify-start mt-4'>
+          <Heading as='h2' size='xl'>
+            Installation
+          </Heading>
           <div className='w-full rounded-lg border-foreground bg-accent'>
             <Code language='toml'>
               {'[dependencies]'}
@@ -47,75 +54,81 @@ export default function Home() {
           </div>
         </section>
 
-        <section className='w-full min-w-screen-sm  max-w-screen-lg grid grid-cols-1 gap-2 md:grid-cols-2 lg:gap-4 items-stretch'>
-          <Card className='flex-grow'>
-            <CardHeader>
-              <WandIcon className='w-5 h-5 stroke-foreground' strokeWidth={1.5} />
-              <CardTitle>Automatic Palette Extraction</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className='text-balance text-sm text-muted-foreground'>
-                Automatically extract prominent color palettes from images to streamline your design process with ease.
-              </p>
-            </CardContent>
-          </Card>
-          <Card className='flex-grow'>
-            <CardHeader>
-              <PipetteIcon className='w-5 h-5 stroke-foreground' strokeWidth={1.5} />
-              <CardTitle>Detailed Color Insights</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className='text-balance text-sm text-foreground'>
-                Provide detailed color data including color code, position, population, and ratio of each swatch.
-              </p>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardHeader>
-              <CogIcon className='w-5 h-5 stroke-foreground' strokeWidth={1.5} />
-              <CardTitle>Multiple Algorithms Support</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className='text-balance text-sm text-foreground'>
-                Support multiple color extraction algorithms including DBSCAN, DBSCAN++, and K-means++.
-              </p>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardHeader>
-              <PaletteIcon className='w-5 h-5 stroke-foreground' strokeWidth={1.5} />
-              <CardTitle>Theme-Based Color Selection</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className='text-balance text-sm text-foreground'>
-                Automatically select colors based on the specified theme including colorful, vivid, light and dark, and
-                more.
-              </p>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardHeader>
-              <SwatchIcon className='w-5 h-5 stroke-foreground' strokeWidth={1.5} />
-              <CardTitle>Multiple Color Spaces Support</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className='text-balance text-sm text-muted-foreground'>
-                Support multiple color space conversion including RGB, HSL, CIE L*a*b* and more. Enable you to use the
-                color data in your favorite color space.
-              </p>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardHeader>
-              <CodeIcon className='w-5 h-5 stroke-foreground' strokeWidth={1.5} />
-              <CardTitle>Multiple Languages Support</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className='text-balance text-sm text-muted-foreground'>
-                Available as a Rust library, WebAssembly, and CLI. Use it in your favorite programming language.
-              </p>
-            </CardContent>
-          </Card>
+        <section className='w-full min-w-screen-sm max-w-screen-lg flex flex-col items-start justify-start mt-4'>
+          <Heading as='h2' size='xl'>
+            Features
+          </Heading>
+          <div className='w-full h-fit grid grid-cols-1 gap-2 md:grid-cols-2 lg:gap-4 items-stretch'>
+            <Card className='flex-grow'>
+              <CardHeader>
+                <WandIcon className='w-5 h-5 stroke-foreground' strokeWidth={1.5} />
+                <CardTitle>Automatic Palette Extraction</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className='text-balance text-sm text-muted-foreground'>
+                  Automatically extract prominent color palettes from images to streamline your design process with
+                  ease.
+                </p>
+              </CardContent>
+            </Card>
+            <Card className='flex-grow'>
+              <CardHeader>
+                <PipetteIcon className='w-5 h-5 stroke-foreground' strokeWidth={1.5} />
+                <CardTitle>Detailed Color Insights</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className='text-balance text-sm text-foreground'>
+                  Provide detailed color data including color code, position, population, and ratio of each swatch.
+                </p>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CogIcon className='w-5 h-5 stroke-foreground' strokeWidth={1.5} />
+                <CardTitle>Multiple Algorithms Support</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className='text-balance text-sm text-foreground'>
+                  Support multiple color extraction algorithms including DBSCAN, DBSCAN++, and K-means++.
+                </p>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <PaletteIcon className='w-5 h-5 stroke-foreground' strokeWidth={1.5} />
+                <CardTitle>Theme-Based Color Selection</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className='text-balance text-sm text-foreground'>
+                  Automatically select colors based on the specified theme including colorful, vivid, light and dark,
+                  and more.
+                </p>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <SwatchIcon className='w-5 h-5 stroke-foreground' strokeWidth={1.5} />
+                <CardTitle>Multiple Color Spaces Support</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className='text-balance text-sm text-muted-foreground'>
+                  Support multiple color space conversion including RGB, HSL, CIE L*a*b* and more. Enable you to use the
+                  color data in your favorite color space.
+                </p>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CodeIcon className='w-5 h-5 stroke-foreground' strokeWidth={1.5} />
+                <CardTitle>Multiple Languages Support</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className='text-balance text-sm text-muted-foreground'>
+                  Available as a Rust library, WebAssembly, and CLI. Use it in your favorite programming language.
+                </p>
+              </CardContent>
+            </Card>
+          </div>
         </section>
       </main>
 

--- a/src/components/card/title.tsx
+++ b/src/components/card/title.tsx
@@ -1,5 +1,6 @@
 import type { FC, ReactNode } from 'react';
 import { cn } from '@/utils';
+import { Heading } from '@/components/typography';
 
 /**
  * The card title component props.
@@ -22,7 +23,11 @@ interface CardTitleProps {
  * @param props The card title component props.
  */
 const CardTitle: FC<CardTitleProps> = ({ className, children }) => {
-  return <h3 className={cn('text-lg font-bold tracking-normal', className)}>{children}</h3>;
+  return (
+    <Heading as='h3' size='lg' className={className}>
+      {children}
+    </Heading>
+  );
 };
 CardTitle.displayName = 'CardTitle';
 

--- a/src/components/code/code.tsx
+++ b/src/components/code/code.tsx
@@ -6,7 +6,7 @@ import { CopyButton } from '@/components/buttons';
 import { type Language, useShiki } from '@/providers/shiki-provider';
 import { cn } from '@/utils';
 
-const Variants = cva('font-mono', {
+const CodeVariants = cva('font-mono', {
   variants: {
     size: {
       sm: 'text-xs',
@@ -22,7 +22,7 @@ const Variants = cva('font-mono', {
 /**
  * The code component props.
  */
-interface CodeProps extends VariantProps<typeof Variants> {
+interface CodeProps extends VariantProps<typeof CodeVariants> {
   /**
    * The language of the code block.
    */
@@ -53,7 +53,7 @@ const Code: FC<CodeProps> = ({ size, language, children }) => {
   return (
     <div className='relative p-4 overflow-x-auto'>
       <CopyButton className='absolute top-2 right-2 z-10' text={code} duration={1000} />
-      <div className={cn(Variants({ size }))}>
+      <div className={cn(CodeVariants({ size }))}>
         <div
           className='bg-green5'
           // biome-ignore lint/security/noDangerouslySetInnerHtml: This is a code snippet and should be rendered as HTML.

--- a/src/components/layouts/header.tsx
+++ b/src/components/layouts/header.tsx
@@ -3,6 +3,7 @@ import type { FC } from 'react';
 import { ButtonLink } from '@/components/navigation';
 import { GitHubIcon } from '@/components/icons';
 import { ThemeButton } from '@/components/buttons';
+import { Heading } from '@/components/typography';
 
 /**
  * The header component that displays the site title and navigation links.
@@ -12,7 +13,9 @@ const Header: FC = () => {
     <header className='container sticky top-0 left-0 right-0 z-50 bg-background/80 supports-[backdrop-filter]:bg-background/60 backdrop-blur-2xl border-b border-border/80'>
       <div className='flex flex-row items-center max-w-screen-lg mx-auto py-2'>
         <Link href='/'>
-          <h1 className='flex-none text-base font-extrabold tracking-normal leading-none uppercase'>Auto Palette</h1>
+          <Heading as='h1' className='flex-none font-extrabold leading-none uppercase'>
+            Auto Palette
+          </Heading>
         </Link>
 
         <div className='flex flex-row justify-end flex-1'>

--- a/src/components/swatch/swatch-marker.tsx
+++ b/src/components/swatch/swatch-marker.tsx
@@ -2,7 +2,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { type CSSProperties, forwardRef, useMemo } from 'react';
 import { cn } from '@/utils';
 
-const markerVariants = cva(
+const MarkerVariants = cva(
   'absolute -translate-x-1/2 -translate-y-1/2 z-10 rounded-full border-2 border-accent shadow-md',
   {
     variants: {
@@ -21,7 +21,7 @@ const markerVariants = cva(
 /**
  * The properties of the marker component.
  */
-interface SwatchMarkerProps extends VariantProps<typeof markerVariants> {
+interface SwatchMarkerProps extends VariantProps<typeof MarkerVariants> {
   /**
    * The class name of the marker.
    */
@@ -64,7 +64,7 @@ const SwatchMarker = forwardRef<HTMLDivElement, SwatchMarkerProps>(
     );
 
     return (
-      <div className={cn(markerVariants({ size, className }))} style={positionStyle} ref={ref} {...props}>
+      <div className={cn(MarkerVariants({ size, className }))} style={positionStyle} ref={ref} {...props}>
         <div className='w-full h-full rounded-full' style={backgroundStyle}>
           <span className='sr-only'>Color marker</span>
         </div>

--- a/src/components/typography/heading.tsx
+++ b/src/components/typography/heading.tsx
@@ -1,0 +1,58 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+import { forwardRef, type PropsWithChildren } from 'react';
+import { cn } from '@/utils';
+
+const HeadingVariants = cva('py-2 font-bold leading-normal tracking-normal', {
+  variants: {
+    size: {
+      xl: 'text-2xl',
+      lg: 'text-lg',
+      md: 'text-base',
+      sm: 'text-sm',
+    },
+  },
+  defaultVariants: {
+    size: 'md',
+  },
+});
+
+type HeadingTag = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+
+type HeadingSize = 'xl' | 'lg' | 'md' | 'sm';
+
+const HeadingTags: Record<HeadingSize, HeadingTag> = {
+  xl: 'h1',
+  lg: 'h2',
+  md: 'h3',
+  sm: 'h4',
+};
+
+/**
+ * The properties of the heading component.
+ */
+interface HeadingProps extends VariantProps<typeof HeadingVariants>, PropsWithChildren {
+  /**
+   * The tag to render the heading as.
+   */
+  readonly as?: HeadingTag;
+
+  /**
+   * The class name to apply to the heading.
+   */
+  readonly className?: string;
+}
+
+/**
+ * The heading component.
+ */
+const Heading = forwardRef<HTMLHeadingElement, HeadingProps>(({ as, size, className, children, ...props }, ref) => {
+  const Component = as || HeadingTags[size || 'md'];
+  return (
+    <Component ref={ref} className={cn(HeadingVariants({ size, className }))} {...props}>
+      {children}
+    </Component>
+  );
+});
+Heading.displayName = 'Heading';
+
+export { Heading };

--- a/src/components/typography/index.ts
+++ b/src/components/typography/index.ts
@@ -1,0 +1,1 @@
+export * from './heading';

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 
 import { cn } from '@/utils/ui';
 
-const buttonVariants = cva(
+const ButtonVariants = cva(
   'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
@@ -32,16 +32,16 @@ const buttonVariants = cva(
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {
+    VariantProps<typeof ButtonVariants> {
   asChild?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : 'button';
-    return <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />;
+    return <Comp className={cn(ButtonVariants({ variant, size, className }))} ref={ref} {...props} />;
   },
 );
 Button.displayName = 'Button';
 
-export { Button, buttonVariants };
+export { Button, ButtonVariants };

--- a/src/layouts/demo.tsx
+++ b/src/layouts/demo.tsx
@@ -47,7 +47,7 @@ const DemoLayout: FC = () => {
   }, [palette, paletteError]);
 
   return (
-    <section className='w-full min-w-screen-sm  max-w-screen-lg flex items-center justify-start'>
+    <section className='w-full min-w-screen-sm max-w-screen-lg flex flex-col items-start justify-start mt-4'>
       <AspectRatio ref={containerRef} ratio={16 / 9} className='flex items-center justify-center relative'>
         <div className='h-full w-full -z-10 overflow-hidden rounded-lg bg-image-placeholder bg-4'>
           {imageBitmap && (

--- a/test/components/layouts/header.test.tsx
+++ b/test/components/layouts/header.test.tsx
@@ -1,14 +1,16 @@
-import { expect, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { Header } from '@/components/layouts';
 
-test('Header', () => {
-  // Act
-  render(<Header />);
+describe('Header', () => {
+  test('render', () => {
+    // Act
+    render(<Header />);
 
-  // Assert
-  expect(document.querySelector('header')).toBeDefined();
-  expect(screen.getByText('Auto Palette')).toBeDefined();
-  expect(screen.getByText('GitHub')).toBeDefined();
+    // Assert
+    expect(document.querySelector('header')).toBeDefined();
+    expect(screen.getByText('Auto Palette')).toBeDefined();
+    expect(screen.getByText('GitHub')).toBeDefined();
+  });
 });

--- a/test/components/typography/heading.test.tsx
+++ b/test/components/typography/heading.test.tsx
@@ -1,0 +1,14 @@
+import { describe, test, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Heading } from '@/components/typography';
+
+describe('Heading', () => {
+  test('render', () => {
+    // Act
+    render(<Heading>Hello, world!</Heading>);
+
+    // Assert
+    expect(document.querySelector('h3')).toBeDefined();
+    expect(screen.getByText('Hello, world!')).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Description

This PR introduces the `Heading` component, designed to support dynamic typography across the application.  
It allows for the use of `h1` through `h6` HTML tags with size variants including `xl`, `lg`, `md`, and `sm`.

## Related Issue

No related issue.

## Type of Change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

- [x] My changes are consistent with the project's coding style.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guidelines.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
